### PR TITLE
stock price calculation

### DIFF
--- a/res/bandwhich-inkscape.svg
+++ b/res/bandwhich-inkscape.svg
@@ -7,6 +7,7 @@
    viewBox="0 0 112.77548 105.83332"
    version="1.1"
    id="svg1"
+   
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    sodipodi:docname="bandwhich.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -14,6 +15,7 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <sodipodi:namedview
+
      id="namedview1"
      pagecolor="#ffffff"
      bordercolor="#eeeeee"


### PR DESCRIPTION
Hi,

Thanks for this very inspiring project,

I tried to run with my setup:

pandas - 1.3.3
sklearn - 1.0.1
keras - 2.7.0
sns - 0.11.2

**but failed to train the first LSTM model, bellow errors make me not possible to run further code, can you please help check?**

<ipython-input-35-eb59bea3d4e6>:23: DeprecationWarning: KerasClassifier is deprecated, use Sci-Keras (https://github.com/adriangb/scikeras) instead.
  clf_1_lstm=KerasClassifier(build_fn=create_shallow_LSTM,
INFO:tensorflow:Assets written to: ram://5bd8d8ae-cb66-45d2-bb13-5903fd6c167e/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://38ea5584-9d07-4a8c-88c2-f74e551d3f4c/assets
INFO:tensorflow:Assets written to: ram://38ea5584-9d07-4a8c-88c2-f74e551d3f4c/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://9ea10efe-14af-421c-9962-c78a99554f12/assets
INFO:tensorflow:Assets written to: ram://9ea10efe-14af-421c-9962-c78a99554f12/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://57e44642-2efb-4e78-b626-c0f197209886/assets
INFO:tensorflow:Assets written to: ram://57e44642-2efb-4e78-b626-c0f197209886/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://13a86c28-e5ee-4c43-abbe-b7b217eade9d/assets
INFO:tensorflow:Assets written to: ram://13a86c28-e5ee-4c43-abbe-b7b217eade9d/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://131056d1-23bc-4750-b668-83c561674cc2/assets
INFO:tensorflow:Assets written to: ram://131056d1-23bc-4750-b668-83c561674cc2/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://2dc6c586-a131-4148-ae7f-d2adc8886c2f/assets
INFO:tensorflow:Assets written to: ram://2dc6c586-a131-4148-ae7f-d2adc8886c2f/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
INFO:tensorflow:Assets written to: ram://9bf036a3-3a4f-44c5-b584-e5b152e6e483/assets
INFO:tensorflow:Assets written to: ram://9bf036a3-3a4f-44c5-b584-e5b152e6e483/assets
WARNING:absl:<keras.layers.recurrent.LSTMCell object at 0x7f3a205a12b0> has the same name 'LSTMCell' as a built-in Keras object. Consider renaming <class 'keras.layers.recurrent.LSTMCell'> to avoid naming conflicts when loading with `tf.keras.models.load_model`. If renaming is not possible, pass the object in the `custom_objects` parameter of the load function.
/home/flynn/.local/lib/python3.9/site-packages/sklearn/model_selection/_search.py:969: UserWarning: One or more of the test scores are non-finite: [nan]
  warnings.warn(


accuracy of the best model:  nan


Best hyperparameters:
epochs: 1
batch_size: 1
dropout_rate: 0.1
recurrent_dropout: 0.1


Running Time: 122.3699893951416
[document for bug solvin.txt](https://github.com/user-attachments/files/17330398/document.for.bug.solvin.txt)
